### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Simple Article for Django
 =========================
 [![Build Status](https://travis-ci.org/zniper/simple-article.svg?branch=master)](https://travis-ci.org/zniper/simple-article)
 [![Coverage Status](https://coveralls.io/repos/zniper/simple-article/badge.svg?branch=master)](https://coveralls.io/r/zniper/simple-article?branch=master)
-[![Downloads](https://pypip.in/download/simple-article/badge.svg)](https://pypi.python.org/pypi/simple-article/)
-[![Latest Version](https://pypip.in/version/simple-article/badge.svg)](https://pypi.python.org/pypi/simple-article/)
+[![Downloads](https://img.shields.io/pypi/dm/simple-article.svg)](https://pypi.python.org/pypi/simple-article/)
+[![Latest Version](https://img.shields.io/pypi/v/simple-article.svg)](https://pypi.python.org/pypi/simple-article/)
 
 **simple-article** is a Django application which provides a simple Article model. That model could be a good start for simple blog or news, without the needs for installation much of other 3rd party packages.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20simple-article))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `simple-article`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.